### PR TITLE
Update client version number for next AP version

### DIFF
--- a/src/sm64ap.cpp
+++ b/src/sm64ap.cpp
@@ -246,7 +246,7 @@ void SM64AP_ResetItems() {
 }
 
 void SM64AP_GenericInit() {
-    AP_NetworkVersion version = {0,3,0};
+    AP_NetworkVersion version = {0,3,4};
     AP_SetClientVersion(&version);
     AP_SetDeathLinkSupported(true);
     AP_SetItemClearCallback(&SM64AP_ResetItems);


### PR DESCRIPTION
Since these include breaking changes on older AP server versions, it's a good idea to update this as well once the official release is pushed.