### PR TITLE
Move moat logic to server rather than save file

### DIFF
--- a/src/game/behaviors/moat_drainer.inc.c
+++ b/src/game/behaviors/moat_drainer.inc.c
@@ -1,7 +1,8 @@
 // moat_drainer.c.inc
+#include "sm64ap.h"
 
 void bhv_invisible_objects_under_bridge_init(void) {
-    if (save_file_get_flags() & SAVE_FLAG_MOAT_DRAINED) {
+    if (SM64AP_MoatDrained()) {
         gEnvironmentRegions[6] = -800;
         gEnvironmentRegions[12] = -800;
     }

--- a/src/game/behaviors/moat_grill.inc.c
+++ b/src/game/behaviors/moat_grill.inc.c
@@ -1,7 +1,8 @@
 // moat_grill.c.inc
+#include "sm64ap.h"
 
 void bhv_moat_grills_loop(void) {
-    if (save_file_get_flags() & SAVE_FLAG_MOAT_DRAINED)
+    if (SM64AP_MoatDrained())
         cur_obj_set_model(MODEL_NONE);
     else
         load_object_collision_model();

--- a/src/game/behaviors/water_pillar.inc.c
+++ b/src/game/behaviors/water_pillar.inc.c
@@ -29,7 +29,7 @@ void water_level_pillar_undrained(void) {
                 if (sp1C->oAction > 1) {
                     o->oAction++;
 
-                    SM64AP_SetMoatDrained(1);
+                    SM64AP_SetMoatDrained();
                     play_puzzle_jingle();
                 }
             }

--- a/src/game/behaviors/water_pillar.inc.c
+++ b/src/game/behaviors/water_pillar.inc.c
@@ -1,4 +1,5 @@
 // water_pillar.c.inc
+#include "sm64ap.h"
 
 void water_level_pillar_undrained(void) {
     struct Object *sp1C;
@@ -28,7 +29,7 @@ void water_level_pillar_undrained(void) {
                 if (sp1C->oAction > 1) {
                     o->oAction++;
 
-                    save_file_set_flags(SAVE_FLAG_MOAT_DRAINED);
+                    SM64AP_SetMoatDrained(1);
                     play_puzzle_jingle();
                 }
             }
@@ -58,7 +59,7 @@ void water_level_pillar_drained(void) {
 }
 
 void bhv_water_level_pillar_init(void) {
-    if (save_file_get_flags() & SAVE_FLAG_MOAT_DRAINED)
+    if (SM64AP_MoatDrained())
         o->oWaterLevelPillarUnkF8 = 1;
 }
 

--- a/src/sm64ap.cpp
+++ b/src/sm64ap.cpp
@@ -28,7 +28,6 @@ bool sm64_have_wingcap = false;
 bool sm64_have_metalcap = false;
 bool sm64_have_vanishcap = false;
 int sm64_moat_state = 0;
-bool moat_state_checked = false;
 bool sm64_have_cannon[15];
 int sm64_completion_type = 0;
 std::bitset<SM64AP_NUM_ABILITIES> sm64_have_abilities;
@@ -306,7 +305,6 @@ void SM64AP_SetReplyHandler(AP_SetReply reply) {
     }
     else if (reply.key == AP_GetPrivateServerDataPrefix() + "MoatDrained") {
         sm64_moat_state = *(int *) (reply.value);
-        moat_state_checked = true;
     }
 }
 
@@ -409,7 +407,6 @@ void SM64AP_CheckMoatState() {
     moat_request.type = AP_DataType::Int;
     moat_request.value = &sm64_moat_state;
     AP_GetServerData(&moat_request);
-    moat_state_checked = true;
 }
 
 void SM64AP_SetMoatDrained(int flag) {

--- a/src/sm64ap.cpp
+++ b/src/sm64ap.cpp
@@ -225,10 +225,6 @@ int SM64AP_CourseToTTC() {
     return -1; // Error Cond
 }
 
-void SM64AP_SetMoatState(int action) {
-    sm64_moat_state = action;
-}
-
 void SM64AP_SetClockToTTCAction(int* action) {
     sm64_clockaction = action;
 }

--- a/src/sm64ap.h
+++ b/src/sm64ap.h
@@ -93,7 +93,7 @@ AP_EXTERN_C void SM64AP_PrintNext();
 AP_EXTERN_C void SM64AP_FinishBowser(int i);
 
 // Used to send and receive moat state
-AP_EXTERN_C void SM64AP_SetMoatDrained(int);
+AP_EXTERN_C void SM64AP_SetMoatDrained();
 AP_EXTERN_C bool SM64AP_MoatDrained();
 
 // Check for switch state (used for initial switch state on level load)

--- a/src/sm64ap.h
+++ b/src/sm64ap.h
@@ -92,6 +92,10 @@ AP_EXTERN_C void SM64AP_PrintNext();
 // Called on each Bowser stage completion, i is bowser index. Will send StoryComplete depending on completion option.
 AP_EXTERN_C void SM64AP_FinishBowser(int i);
 
+// Used to send and receive moat state
+AP_EXTERN_C void SM64AP_SetMoatDrained(int);
+AP_EXTERN_C bool SM64AP_MoatDrained();
+
 // Check for switch state (used for initial switch state on level load)
 AP_EXTERN_C bool SM64AP_PressedSwitch(int);
 


### PR DESCRIPTION
Follow up to #6, fixing the last remaining major issue with using existing save files. Moat state is now saved to and loaded from the server, rather than the internal save file.