### PR TITLE
Nonstop mode updates

### DIFF
--- a/enhancements/nonstop_mode_always_enabled.patch
+++ b/enhancements/nonstop_mode_always_enabled.patch
@@ -1,3 +1,9 @@
+From a5c04e3b7166d02236be73b82d903e0f0945314f Mon Sep 17 00:00:00 2001
+From: GateGuy <gateguy33@gmail.com>
+Date: Sat, 13 Jun 2020 19:20:34 -0400
+Subject: [PATCH] Non-Stop Mode Always Enabled
+
+---
 diff --git a/src/game/behaviors/ddd_pole.inc.c b/src/game/behaviors/ddd_pole.inc.c
 index cc82102..a155806 100644
 --- a/src/game/behaviors/ddd_pole.inc.c

--- a/enhancements/nonstop_mode_always_enabled.patch
+++ b/enhancements/nonstop_mode_always_enabled.patch
@@ -1,63 +1,3 @@
-From a5c04e3b7166d02236be73b82d903e0f0945314f Mon Sep 17 00:00:00 2001
-From: GateGuy <gateguy33@gmail.com>
-Date: Sat, 13 Jun 2020 19:20:34 -0400
-Subject: [PATCH] Non-Stop Mode Always Enabled
-
----
-diff --git a/src/game/interaction.c b/src/game/interaction.c
-index ec4026e..ba4d764 100644
---- a/src/game/interaction.c
-+++ b/src/game/interaction.c
-@@ -765,6 +765,10 @@ u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct O
-     u32 starIndex;
-     u32 starGrabAction = ACT_STAR_DANCE_EXIT;
-     u32 noExit = (o->oInteractionSubtype & INT_SUBTYPE_NO_EXIT) != 0;
-+    u8 stayInLevelCommon = !(m->controller->buttonDown & L_TRIG || gCurrLevelNum == LEVEL_BOWSER_1 || gCurrLevelNum == LEVEL_BOWSER_2 || gCurrLevelNum == LEVEL_BOWSER_3);
-+    if (stayInLevelCommon == TRUE) {
-+        noExit = TRUE;
-+    }
-     u32 grandStar = (o->oInteractionSubtype & INT_SUBTYPE_GRAND_STAR) != 0;
- 
-     if (m->health >= 0x100) {
-@@ -822,7 +826,11 @@ u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct O
-             return set_mario_action(m, ACT_JUMBO_STAR_CUTSCENE, 0);
-         }
- 
--        return set_mario_action(m, starGrabAction, noExit + 2 * grandStar);
-+        if (stayInLevelCommon == FALSE) {
-+            return set_mario_action(m, starGrabAction, noExit + 2 * grandStar);
-+        }
-+        //If nonstop StayInLevel is enabled, autosave
-+        save_file_do_save(gCurrSaveFileNum - 1);
-     }
- 
-     return FALSE;
-diff --git a/src/game/mario_actions_cutscene.c b/src/game/mario_actions_cutscene.c
-index 4fdfd9b..9243aa8 100644
---- a/src/game/mario_actions_cutscene.c
-+++ b/src/game/mario_actions_cutscene.c
-@@ -599,6 +599,9 @@ s32 act_debug_free_move(struct MarioState *m) {
-     return FALSE;
- }
- 
-+// camera.c
-+BAD_RETURN(s32) cutscene_exit_painting_end(struct Camera *c);
-+
- // star dance handler
- void general_star_dance_handler(struct MarioState *m, s32 isInWater) {
-     s32 dialogID;
-@@ -646,6 +649,11 @@ void general_star_dance_handler(struct MarioState *m, s32 isInWater) {
-             set_mario_action(m, ACT_READING_AUTOMATIC_DIALOG, dialogID);
-         } else {
-             set_mario_action(m, isInWater ? ACT_WATER_IDLE : ACT_IDLE, 0);
-+            set_fov_function(CAM_FOV_DEFAULT);
-+            // fix camera bug when getting a star underwater with StayInLevel cheat enabled
-+            if (isInWater) {
-+                cutscene_exit_painting_end(m->area->camera);
-+            }
-         }
-     }
- }
 diff --git a/src/game/behaviors/ddd_pole.inc.c b/src/game/behaviors/ddd_pole.inc.c
 index cc82102..a155806 100644
 --- a/src/game/behaviors/ddd_pole.inc.c
@@ -102,4 +42,65 @@ index cc82102..a155806 100644
 +    } else {
 +        o->oPosY = -10000.0f;
 +    }
+ }
+diff --git a/src/game/interaction.c b/src/game/interaction.c
+index 474b5e8..0285b1f 100644
+--- a/src/game/interaction.c
++++ b/src/game/interaction.c
+@@ -765,10 +765,16 @@ u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct O
+     u32 starIndex;
+     u32 starGrabAction = ACT_STAR_DANCE_EXIT;
+     u32 noExit = (o->oInteractionSubtype & INT_SUBTYPE_NO_EXIT) != 0;
++    u8 stayInLevelCommon = !(m->controller->buttonDown & L_TRIG || gCurrLevelNum == LEVEL_BOWSER_1 || gCurrLevelNum == LEVEL_BOWSER_2 || gCurrLevelNum == LEVEL_BOWSER_3);
+     u32 grandStar = (o->oInteractionSubtype & INT_SUBTYPE_GRAND_STAR) != 0;
+ 
+     if (m->health >= 0x100) {
+-        mario_stop_riding_and_holding(m);
++        if (stayInLevelCommon == TRUE) {
++            noExit = TRUE;
++        }
++        else {
++            mario_stop_riding_and_holding(m);
++        }
+         queue_rumble_data(5, 80);
+ 
+         if (!noExit) {
+@@ -822,7 +828,11 @@ u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct O
+             return set_mario_action(m, ACT_JUMBO_STAR_CUTSCENE, 0);
+         }
+ 
+-        return set_mario_action(m, starGrabAction, noExit + 2 * grandStar);
++        if (stayInLevelCommon == FALSE) {
++            return set_mario_action(m, starGrabAction, noExit + 2 * grandStar);
++        }
++        //If nonstop StayInLevel is enabled, autosave
++        save_file_do_save(gCurrSaveFileNum - 1);
+     }
+ 
+     return FALSE;
+diff --git a/src/game/mario_actions_cutscene.c b/src/game/mario_actions_cutscene.c
+index 4fdfd9b..9243aa8 100644
+--- a/src/game/mario_actions_cutscene.c
++++ b/src/game/mario_actions_cutscene.c
+@@ -599,6 +599,9 @@ s32 act_debug_free_move(struct MarioState *m) {
+     return FALSE;
+ }
+ 
++// camera.c
++BAD_RETURN(s32) cutscene_exit_painting_end(struct Camera *c);
++
+ // star dance handler
+ void general_star_dance_handler(struct MarioState *m, s32 isInWater) {
+     s32 dialogID;
+@@ -646,6 +649,11 @@ void general_star_dance_handler(struct MarioState *m, s32 isInWater) {
+             set_mario_action(m, ACT_READING_AUTOMATIC_DIALOG, dialogID);
+         } else {
+             set_mario_action(m, isInWater ? ACT_WATER_IDLE : ACT_IDLE, 0);
++            set_fov_function(CAM_FOV_DEFAULT);
++            // fix camera bug when getting a star underwater with StayInLevel cheat enabled
++            if (isInWater) {
++                cutscene_exit_painting_end(m->area->camera);
++            }
+         }
+     }
  }

--- a/enhancements/nonstop_mode_always_enabled.patch
+++ b/enhancements/nonstop_mode_always_enabled.patch
@@ -58,3 +58,48 @@ index 4fdfd9b..9243aa8 100644
          }
      }
  }
+diff --git a/src/game/behaviors/ddd_pole.inc.c b/src/game/behaviors/ddd_pole.inc.c
+index cc82102..a155806 100644
+--- a/src/game/behaviors/ddd_pole.inc.c
++++ b/src/game/behaviors/ddd_pole.inc.c
+@@ -1,23 +1,27 @@
+ #include "../../sm64ap.h"
+ 
+ void bhv_ddd_pole_init(void) {
+-    if (!SM64AP_CheckedLoc(SM64AP_ID_KEY2) || !SM64AP_CheckedLoc(3626056)) {
+-        obj_mark_for_deletion(o);
+-    } else {
+-        o->hitboxDownOffset = 100.0f;
+-        o->oDDDPoleMaxOffset = 100.0f * o->oBehParams2ndByte;
+-    }
++    o->oHomeY = o->oPosY;
++    o->hitboxDownOffset = 100.0f;
++    o->oDDDPoleMaxOffset = 100.0f * o->oBehParams2ndByte;
+ }
+ 
+ void bhv_ddd_pole_update(void) {
+-    if (o->oTimer > 20) {
+-        o->oDDDPoleOffset += o->oDDDPoleVel;
++    if (SM64AP_CheckedLoc(SM64AP_ID_KEY2) && SM64AP_CheckedLoc(3626056)) {
++        if (o->oPosY != o->oHomeY) {
++            o->oPosY = o->oHomeY;
++        }
++        if (o->oTimer > 20) {
++            o->oDDDPoleOffset += o->oDDDPoleVel;
+ 
+-        if (clamp_f32(&o->oDDDPoleOffset, 0.0f, o->oDDDPoleMaxOffset)) {
+-            o->oDDDPoleVel = -o->oDDDPoleVel;
+-            o->oTimer = 0;
++            if (clamp_f32(&o->oDDDPoleOffset, 0.0f, o->oDDDPoleMaxOffset)) {
++                o->oDDDPoleVel = -o->oDDDPoleVel;
++                o->oTimer = 0;
++            }
+         }
+-    }
+ 
+-    obj_set_dist_from_home(o->oDDDPoleOffset);
++        obj_set_dist_from_home(o->oDDDPoleOffset);
++    } else {
++        o->oPosY = -10000.0f;
++    }
+ }

--- a/enhancements/nonstop_mode_always_enabled.patch
+++ b/enhancements/nonstop_mode_always_enabled.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Non-Stop Mode Always Enabled
 
 ---
 diff --git a/src/game/behaviors/ddd_pole.inc.c b/src/game/behaviors/ddd_pole.inc.c
-index cc82102..a155806 100644
+index cd4d884..4df90f8 100644
 --- a/src/game/behaviors/ddd_pole.inc.c
 +++ b/src/game/behaviors/ddd_pole.inc.c
 @@ -1,23 +1,27 @@
  #include "../../sm64ap.h"
  
  void bhv_ddd_pole_init(void) {
--    if (!SM64AP_CheckedLoc(SM64AP_ID_KEY2) || !SM64AP_CheckedLoc(3626056)) {
+-    if (!SM64AP_CheckedLoc(SM64AP_ID_KEY2) || !SM64AP_CheckedLoc(SM64AP_LOCATIONID_BOARDBOWSERSSUB)) {
 -        obj_mark_for_deletion(o);
 -    } else {
 -        o->hitboxDownOffset = 100.0f;
@@ -26,7 +26,7 @@ index cc82102..a155806 100644
  void bhv_ddd_pole_update(void) {
 -    if (o->oTimer > 20) {
 -        o->oDDDPoleOffset += o->oDDDPoleVel;
-+    if (SM64AP_CheckedLoc(SM64AP_ID_KEY2) && SM64AP_CheckedLoc(3626056)) {
++    if (SM64AP_CheckedLoc(SM64AP_ID_KEY2) && SM64AP_CheckedLoc(SM64AP_LOCATIONID_BOARDBOWSERSSUB)) {
 +        if (o->oPosY != o->oHomeY) {
 +            o->oPosY = o->oHomeY;
 +        }


### PR DESCRIPTION
Fixes three issues with the Nonstop mode patch.

- When BitFS has already been beaten, collecting the star "Board Bowser's Sub" now spawns in the "Pole-Jumping for Red Coins" poles. ([GIF](https://github.com/N00byKing/sm64ex/assets/35675593/9e96e7b0-755f-47f2-8d8b-bd5bf370e33b))
- Fix crash that occurs when holding an object (such as a baby penguin, box, or Bob-Omb) when collecting a star
- Fix glitch in which a Koopa Shell that is being ridden would turn invisible when collecting a star
