### PR TITLE
Add code needed for upcoming "Progressive Jump" option

### DIFF
--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -35,6 +35,7 @@
 #define TEXT_CANYON _("Cannon Unlocked")
 #endif
 // Moves
+#define TEXT_DOUBLE_JUMP _("DOUBLE JUMP")
 #define TEXT_TRIPLE_JUMP _("TRIPLE JUMP")
 #define TEXT_LONG_JUMP _("LONG JUMP")
 #define TEXT_BACKFLIP _("BACKFLIP")

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -2714,7 +2714,7 @@ s16 render_pause_courses_and_castle(void) {
     print_text(GFX_DIMENSIONS_RECT_FROM_RIGHT_EDGE(78)+26, 209-70, SM64AP_HaveCap(8) ? "Y" : "N");
     s16 x = -32;
     s16 y = 170;
-    s16 spacing = 18;
+    s16 spacing = 16;
     print_text(GFX_DIMENSIONS_RECT_FROM_LEFT_EDGE(20), 209-20, "ABILITIES");
     gSPDisplayList(gDisplayListHead++, dl_rgba16_text_begin);
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -2714,54 +2714,52 @@ s16 render_pause_courses_and_castle(void) {
     print_text(GFX_DIMENSIONS_RECT_FROM_RIGHT_EDGE(78)+26, 209-70, SM64AP_HaveCap(8) ? "Y" : "N");
     s16 x = -32;
     s16 y = 170;
-    s16 spacing = 16;
+    s16 spacing = 18;
     print_text(GFX_DIMENSIONS_RECT_FROM_LEFT_EDGE(20), 209-20, "ABILITIES");
     gSPDisplayList(gDisplayListHead++, dl_rgba16_text_begin);
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);
-
-    if (SM64AP_CanDoubleJump()) {
+    if (SM64AP_CanTripleJump()) {
+        u8 str_triple_jump[] = { TEXT_TRIPLE_JUMP };
+        print_generic_string(x, y, str_triple_jump);
+    } else if (SM64AP_CanDoubleJump()) {
         u8 str_double_jump[] = { TEXT_DOUBLE_JUMP };
         print_generic_string(x, y, str_double_jump);
     }
-    if (SM64AP_CanTripleJump()) {
-        u8 str_triple_jump[] = { TEXT_TRIPLE_JUMP };
-        print_generic_string(x, y - spacing, str_triple_jump);
-    }
     if (SM64AP_CanLongJump()) {
         u8 str_long_jump[] = { TEXT_LONG_JUMP };
-        print_generic_string(x, y - spacing*2, str_long_jump);
+        print_generic_string(x, y - spacing, str_long_jump);
     }
     if (SM64AP_CanBackflip()) {
         u8 str_backflip[] = { TEXT_BACKFLIP };
-        print_generic_string(x, y - spacing*3, str_backflip);
+        print_generic_string(x, y - spacing*2, str_backflip);
     }
     if (SM64AP_CanSideFlip()) {
         u8 str_side_flip[] = { TEXT_SIDE_FLIP };
-        print_generic_string(x, y - spacing*4, str_side_flip);
+        print_generic_string(x, y - spacing*3, str_side_flip);
     }
     if (SM64AP_CanWallKick()) {
         u8 str_wall_kick[] = { TEXT_WALL_KICK };
-        print_generic_string(x, y - spacing*5, str_wall_kick);
+        print_generic_string(x, y - spacing*4, str_wall_kick);
     }
     if (SM64AP_CanDive()) {
         u8 str_dive[] = { TEXT_DIVE };
-        print_generic_string(x, y - spacing*6, str_dive);
+        print_generic_string(x, y - spacing*5, str_dive);
     }
     if (SM64AP_CanGroundPound()) {
         u8 str_ground_pound[] = { TEXT_GROUND_POUND };
-        print_generic_string(x, y - spacing*7, str_ground_pound);
+        print_generic_string(x, y - spacing*6, str_ground_pound);
     }
     if (SM64AP_CanKick()) {
         u8 str_kick[] = { TEXT_KICK };
-        print_generic_string(x, y - spacing*8, str_kick);
+        print_generic_string(x, y - spacing*7, str_kick);
     }
     if (SM64AP_CanClimb()) {
         u8 str_climb[] = { TEXT_CLIMB };
-        print_generic_string(x, y - spacing*9, str_climb);
+        print_generic_string(x, y - spacing*8, str_climb);
     }
     if (SM64AP_CanLedgeGrab()) {
         u8 str_ledge_grab[] = { TEXT_LEDGE_GRAB };
-        print_generic_string(x, y - spacing*10, str_ledge_grab);
+        print_generic_string(x, y - spacing*9, str_ledge_grab);
     }
     return 0;
 }

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -2718,45 +2718,50 @@ s16 render_pause_courses_and_castle(void) {
     print_text(GFX_DIMENSIONS_RECT_FROM_LEFT_EDGE(20), 209-20, "ABILITIES");
     gSPDisplayList(gDisplayListHead++, dl_rgba16_text_begin);
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);
+
+    if (SM64AP_CanDoubleJump()) {
+        u8 str_double_jump[] = { TEXT_DOUBLE_JUMP };
+        print_generic_string(x, y, str_double_jump);
+    }
     if (SM64AP_CanTripleJump()) {
         u8 str_triple_jump[] = { TEXT_TRIPLE_JUMP };
-        print_generic_string(x, y, str_triple_jump);
+        print_generic_string(x, y - spacing, str_triple_jump);
     }
     if (SM64AP_CanLongJump()) {
         u8 str_long_jump[] = { TEXT_LONG_JUMP };
-        print_generic_string(x, y - spacing, str_long_jump);
+        print_generic_string(x, y - spacing*2, str_long_jump);
     }
     if (SM64AP_CanBackflip()) {
         u8 str_backflip[] = { TEXT_BACKFLIP };
-        print_generic_string(x, y - spacing*2, str_backflip);
+        print_generic_string(x, y - spacing*3, str_backflip);
     }
     if (SM64AP_CanSideFlip()) {
         u8 str_side_flip[] = { TEXT_SIDE_FLIP };
-        print_generic_string(x, y - spacing*3, str_side_flip);
+        print_generic_string(x, y - spacing*4, str_side_flip);
     }
     if (SM64AP_CanWallKick()) {
         u8 str_wall_kick[] = { TEXT_WALL_KICK };
-        print_generic_string(x, y - spacing*4, str_wall_kick);
+        print_generic_string(x, y - spacing*5, str_wall_kick);
     }
     if (SM64AP_CanDive()) {
         u8 str_dive[] = { TEXT_DIVE };
-        print_generic_string(x, y - spacing*5, str_dive);
+        print_generic_string(x, y - spacing*6, str_dive);
     }
     if (SM64AP_CanGroundPound()) {
         u8 str_ground_pound[] = { TEXT_GROUND_POUND };
-        print_generic_string(x, y - spacing*6, str_ground_pound);
+        print_generic_string(x, y - spacing*7, str_ground_pound);
     }
     if (SM64AP_CanKick()) {
         u8 str_kick[] = { TEXT_KICK };
-        print_generic_string(x, y - spacing*7, str_kick);
+        print_generic_string(x, y - spacing*8, str_kick);
     }
     if (SM64AP_CanClimb()) {
         u8 str_climb[] = { TEXT_CLIMB };
-        print_generic_string(x, y - spacing*8, str_climb);
+        print_generic_string(x, y - spacing*9, str_climb);
     }
     if (SM64AP_CanLedgeGrab()) {
         u8 str_ledge_grab[] = { TEXT_LEDGE_GRAB };
-        print_generic_string(x, y - spacing*9, str_ledge_grab);
+        print_generic_string(x, y - spacing*10, str_ledge_grab);
     }
     return 0;
 }

--- a/src/sm64ap.cpp
+++ b/src/sm64ap.cpp
@@ -80,8 +80,8 @@ void SM64AP_RecvItem(int64_t idx, bool notify) {
             sm64_have_cannon[idx-(SM64AP_ID_CANNONUNLOCK(0))] = true;
             break;
         case SM64AP_ID_ABILITY(0):
-            sm64_have_abilities[idx - SM64AP_ABILITY_OFFSET + 1] = sm64_have_abilities[idx - SM64AP_ABILITY_OFFSET];
-            sm64_have_abilities[idx - SM64AP_ABILITY_OFFSET] = true;
+            sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET+1] = sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET];
+            sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET] = true;
             break;
         case SM64AP_ID_ABILITY(1) ... SM64AP_ID_ABILITY(SM64AP_NUM_ABILITIES-1):
             sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET] = true;

--- a/src/sm64ap.cpp
+++ b/src/sm64ap.cpp
@@ -79,8 +79,12 @@ void SM64AP_RecvItem(int64_t idx, bool notify) {
         case SM64AP_ID_CANNONUNLOCK(0) ... SM64AP_ID_CANNONUNLOCK(15-1):
             sm64_have_cannon[idx-(SM64AP_ID_CANNONUNLOCK(0))] = true;
             break;
-        case SM64AP_ID_ABILITY(0) ... SM64AP_ID_ABILITY(SM64AP_NUM_ABILITIES-1):
-            sm64_have_abilities[idx-(SM64AP_ID_ABILITY(0))] = true;
+        case SM64AP_ID_ABILITY(0):
+            sm64_have_abilities[idx - SM64AP_ABILITY_OFFSET + 1] = sm64_have_abilities[idx - SM64AP_ABILITY_OFFSET];
+            sm64_have_abilities[idx - SM64AP_ABILITY_OFFSET] = true;
+            break;
+        case SM64AP_ID_ABILITY(1) ... SM64AP_ID_ABILITY(SM64AP_NUM_ABILITIES-1):
+            sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET] = true;
             break;
     }
 }
@@ -505,8 +509,8 @@ void SM64AP_DeathLinkSend() {
 }
 
 bool SM64AP_CanDoubleJump() {
-    #warning Use doublejump logic once implemented
-    return sm64_have_abilities[SM64AP_ID_TRIPLEJUMP - SM64AP_ABILITY_OFFSET];
+    return sm64_have_abilities[SM64AP_ID_DOUBLEJUMP - SM64AP_ABILITY_OFFSET]
+           || sm64_have_abilities[SM64AP_ID_TRIPLEJUMP - SM64AP_ABILITY_OFFSET];
 }
 
 bool SM64AP_CanTripleJump() {

--- a/src/sm64ap.cpp
+++ b/src/sm64ap.cpp
@@ -271,7 +271,7 @@ void SM64AP_SetCourseMap(std::map<int,int> map) {
 }
 
 void SM64AP_SetMoveRandoVec(int vec) {
-    for (int i = 0; i < SM64AP_NUM_ABILITIES; i++) {
+    for (int i = 1; i < SM64AP_NUM_ABILITIES; i++) { // Start at 1, DJ bit is unnecessary
         sm64_have_abilities[i] = !std::bitset<SM64AP_NUM_ABILITIES>(vec).test(i) || sm64_have_abilities[i];
     }
 }


### PR DESCRIPTION
Implements the ID previously reserved for Double Jump as "Progressive Jump". Similar to how Progressive Key works, this item will give Double Jump upon receiving one of these items, and Triple Jump upon receiving a second. This client is backwards-compatible with current jump behavior, by giving both Double and Triple Jump whenever the Triple Jump item is received (this is why it can be merged directly into the `archipelago` branch rather than needing to be in `ap_test`). Tested and confirmed working on both the current APWorld and the Beta currently found in the Move Rando thread, and works with all officially supported patches.