### PR TITLE
Fix deathlink inconsistencies

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -841,6 +841,7 @@ void initiate_delayed_warp(void) {
                 case WARP_OP_GAME_OVER:
                     save_file_reload();
                     warp_special(-3);
+                    SM64AP_DeathLinkSend();
                     break;
 
                 case WARP_OP_CREDITS_END:

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -1197,6 +1197,7 @@ s32 act_unused_death_exit(struct MarioState *m) {
         play_sound(SOUND_MARIO_OOOF2, m->marioObj->header.gfx.cameraToObject);
 #endif
         m->numLives--;
+        SM64AP_DeathLinkSend();
         // restore 7.75 units of health
         m->healCounter = 31;
     }


### PR DESCRIPTION
- When a game over happens, send a deathlink
- When dying in the TotWC entrance, send a deathlink
- Also fixes deathlinks being received twice when received in the above circumstances

Game over happens before (and instead of) the "exit level death" that deathlink already checks for, so this change adds a deathlink send there. Additionally, the `act_unused_death_exit` is not unused as the function name states, but is instead used when a non-falling death happens in Tower of the Wing Cap (i.e. fall damage, or a received deathlink), or any death (falling included) happens in the TotWC entrance when it leads to any other level