### PR TITLE
Fix crash on JP version when sound is set to Stereo

### DIFF
--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -1346,13 +1346,6 @@ void update_game_sound(void) {
                             break;
                     }
                 }
-#ifdef VERSION_JP
-                else if (soundStatus == SOUND_STATUS_STOPPED) {
-                    func_8031E0E4(bankIndex, index);
-                    gSequencePlayers[SEQ_PLAYER_SFX].channels[channelIndex]->soundScriptIO[0] = 0;
-                    func_8031DFE8(bankIndex, index);
-                }
-#else
                 else if (gSequencePlayers[SEQ_PLAYER_SFX].channels[channelIndex]->layers[0] == NULL) {
                     func_8031E0E4(bankIndex, index);
                     gSoundBanks[bankIndex][index].soundStatus = SOUND_STATUS_STOPPED;
@@ -1364,7 +1357,6 @@ void update_game_sound(void) {
                     gSequencePlayers[SEQ_PLAYER_SFX].channels[channelIndex]->soundScriptIO[0] = 0;
                     func_8031DFE8(bankIndex, index);
                 }
-#endif
                 else if (gSequencePlayers[SEQ_PLAYER_SFX].channels[channelIndex]->layers[0]->enabled == FALSE) {
                     func_8031E0E4(bankIndex, index);
                     gSoundBanks[bankIndex][index].soundStatus = SOUND_STATUS_STOPPED;


### PR DESCRIPTION
Not sure precisely _why_ this crash occurs but seemingly has something to do with an invalid soundbank read based on the code. Unable to personally reproduce a hard crash in Pyramid Puzzle after this fix