### PR TITLE
Remove mission select bypass when a warp checkpoint would be set

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -737,7 +737,7 @@ void initiate_painting_warp(void) {
                 }
 
                 if (!(warpNode.destLevel & 0x80)) {
-                    D_8032C9E0 = check_warp_checkpoint(&warpNode);
+                    D_8032C9E0 = 0;
                 }
 
                 initiate_warp(warpNode.destLevel & 0x7F, warpNode.destArea, warpNode.destNode, 0);

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -737,7 +737,7 @@ void initiate_painting_warp(void) {
                 }
 
                 if (!(warpNode.destLevel & 0x80)) {
-                    D_8032C9E0 = 0;
+                    D_8032C9E0 = FALSE;
                 }
 
                 initiate_warp(warpNode.destLevel & 0x7F, warpNode.destArea, warpNode.destNode, 0);


### PR DESCRIPTION
Mid-level checkpoints are disabled in this mod, but as [reported on Discord](https://discord.com/channels/731205301247803413/937206798014898186/1462622940678852749) the mission select screen is still bypassed when a checkpoint is active. This disables the check to disable mission select