### PR TITLE
Add extra filler items + delayed queue

### DIFF
--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -9,6 +9,7 @@
 #include "camera.h"
 #include "course_table.h"
 #include "dialog_ids.h"
+#include "engine/behavior_script.h"
 #include "engine/math_util.h"
 #include "engine/surface_collision.h"
 #include "game_init.h"
@@ -76,6 +77,8 @@ u32 interact_hoot(struct MarioState *, u32, struct Object *);
 u32 interact_cap(struct MarioState *, u32, struct Object *);
 u32 interact_grabbable(struct MarioState *, u32, struct Object *);
 u32 interact_text(struct MarioState *, u32, struct Object *);
+
+u16 delayedArchTimer = 100;
 
 struct InteractionHandler {
     u32 interactType;
@@ -1745,6 +1748,139 @@ void check_kick_or_punch_wall(struct MarioState *m) {
     }
 }
 
+/**
+ * Update the timer if we're in a course and determine if there's anything to pop
+ */
+void update_arch_delayed_items(struct MarioState *m) {
+    if(gCurrCourseNum < COURSE_MIN || gCurrCourseNum > COURSE_MAX - 1) {
+        return; // Don't update during any section we don't have control or in the castle
+    }
+    if(m->invincTimer > 0) {
+        return; // Don't update when Mario is invincible, we don't want to spawn fire when we can't be burned by it :)
+    }
+    if(gCurrDemoInput != NULL) {
+        return; // Also don't update when we're in the demo screen
+    }
+    switch(m->action) {
+        case ACT_IDLE:
+        case ACT_PANTING:
+        case ACT_HOLD_IDLE:
+        case ACT_HOLD_HEAVY_IDLE:
+        case ACT_STANDING_AGAINST_WALL:
+        case ACT_COUGHING:
+        case ACT_SHIVERING:
+        case ACT_CROUCHING:
+        case ACT_WALKING:
+        case ACT_HOLD_WALKING:
+        case ACT_TURNING_AROUND:
+        case ACT_RIDING_SHELL_GROUND:
+        case ACT_HOLD_HEAVY_WALKING:
+        case ACT_CRAWLING:
+        case ACT_JUMP:
+        case ACT_DOUBLE_JUMP:
+        case ACT_TRIPLE_JUMP:
+        case ACT_BACKFLIP:
+        case ACT_STEEP_JUMP:
+        case ACT_WALL_KICK_AIR:
+        case ACT_SIDE_FLIP:
+        case ACT_LONG_JUMP:
+        case ACT_WATER_JUMP:
+        case ACT_DIVE:
+        case ACT_FREEFALL:
+        case ACT_TOP_OF_POLE_JUMP:
+        case ACT_FLYING:
+        case ACT_RIDING_SHELL_JUMP:
+        case ACT_RIDING_SHELL_FALL:
+        case ACT_WATER_IDLE:
+        case ACT_HOLD_WATER_IDLE:
+        case ACT_BREASTSTROKE:
+        case ACT_HOLD_BREASTSTROKE:
+        case ACT_WATER_PUNCH:
+            break;
+        default:
+            // If we aren't in one of the known Mario states, don't decrement the timer
+            return;
+    }
+    // If we have time left on the timer, decrement and don't do anything else
+    if(delayedArchTimer > 0) {
+        delayedArchTimer--;
+        return;
+    }
+    u32 item = SM64AP_PopDelayedStack();
+    if(item == 0) {
+        return;
+    }
+    delayedArchTimer = 100; // Pop at most one item every 100 frames
+    struct Object *interact;
+    switch(item) {
+        case 0:
+            break;
+        case SM64AP_ID_1_HEALTH_PIP ... SM64AP_ID_FULL_REFILL:
+            if(item == SM64AP_ID_FULL_REFILL) {
+                m->healCounter += 4*8;
+            } else {
+                s16 amtToHeal = (item - SM64AP_ID_1_HEALTH_PIP + 1);
+                m->healCounter += 4*amtToHeal;
+            }
+            break;
+        case SM64AP_ID_BONK_TRAP:
+            interact = spawn_object(m->marioObj, MODEL_NONE, bhvSmallParticleBubbles);
+            interact_bully(m, INTERACT_BULLY, interact);
+            break;
+        case SM64AP_ID_FIRE_TRAP:
+            interact = spawn_object(m->marioObj, MODEL_RED_FLAME, bhvFlameLargeBurningOut);
+            interact_flame(m, INTERACT_FLAME, interact);
+            break;
+        case SM64AP_ID_ELEC_TRAP:
+            interact = spawn_object(m->marioObj, MODEL_NONE, bhvSmallParticleBubbles);
+            m->hurtCounter += 4; // hurt for one pip
+            interact_shock(m, INTERACT_SHOCK, interact);
+            break;
+        case SM64AP_ID_CHUCK_TRAP:
+            m->faceAngle[1] = random_u16();
+            m->forwardVel = 40.0f;
+            m->vel[1] = 40.0f;
+            play_sound(SOUND_OBJ_CHUCKYA_DEATH, gDefaultSoundArgs);
+            play_sound(SOUND_MARIO_WAAAOOOW, m->marioObj->header.gfx.cameraToObject);
+            update_mario_sound_and_camera(m);
+            set_mario_action(m, ACT_THROWN_FORWARD, 0);
+            break;
+        case SM64AP_ID_SPIN_TRAP:
+            interact = spawn_object(m->marioObj, MODEL_SAND_DUST, bhvTweesterSandParticle);
+            mario_stop_riding_and_holding(m);
+            bounce_off_object(m, interact, 80.0f);
+            reset_mario_pitch(m);
+            play_sound(SOUND_ENV_WIND1, m->marioObj->header.gfx.cameraToObject);
+            play_sound(SOUND_MARIO_WAAAOOOW, m->marioObj->header.gfx.cameraToObject);
+            drop_and_set_mario_action(m, ACT_TWIRLING, 0);
+            break;
+        case SM64AP_ID_GUST_TRAP:
+            mario_stop_riding_and_holding(m);
+            m->faceAngle[1] = random_u16();
+            m->unkC4 = 0.4f;
+            m->forwardVel = -24.0f;
+            m->vel[1] = 12.0f;
+
+            play_sound(SOUND_MARIO_WAAAOOOW, m->marioObj->header.gfx.cameraToObject);
+            update_mario_sound_and_camera(m);
+            set_mario_action(m, ACT_GETTING_BLOWN, 0);
+            break;
+        default:
+            break;
+    }
+    // and play the appropriate sound
+    switch(item) {
+        // For all the positive filler, play the ding-ding sound
+        case SM64AP_ID_1_HEALTH_PIP ... SM64AP_ID_FULL_REFILL:
+            play_sound(SOUND_GENERAL2_RIGHT_ANSWER, gDefaultSoundArgs);
+            break;
+        // For all the negative filler, play the buzzer
+        default:
+            play_sound(SOUND_MENU_CAMERA_BUZZ, gDefaultSoundArgs);
+            break;
+    }
+}
+
 void mario_process_interactions(struct MarioState *m) {
     sDelayInvincTimer = FALSE;
     sInvulnerable = (m->action & ACT_FLAG_INVULNERABLE) || m->invincTimer != 0;
@@ -1782,6 +1918,7 @@ void mario_process_interactions(struct MarioState *m) {
     if (!(m->marioObj->collidedObjInteractTypes & INTERACT_WARP)) {
         sJustTeleported = FALSE;
     }
+    update_arch_delayed_items(m);
 }
 
 void check_death_barrier(struct MarioState *m) {

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1865,7 +1865,17 @@ void init_mario(void) {
     if (save_file_get_flags()
         & (SAVE_FLAG_CAP_ON_GROUND | SAVE_FLAG_CAP_ON_KLEPTO | SAVE_FLAG_CAP_ON_UKIKI
            | SAVE_FLAG_CAP_ON_MR_BLIZZARD)) {
-        gMarioState->flags = 0;
+        switch(save_file_get_cap_level()) {
+            case LEVEL_SSL:
+            case LEVEL_SL:
+            case LEVEL_TTM:
+                gMarioState->flags = 0;
+                break;
+            default:
+                gMarioState->flags = (MARIO_CAP_ON_HEAD | MARIO_NORMAL_CAP);
+                save_file_clear_flags(SAVE_FLAG_CAP_ON_GROUND | SAVE_FLAG_CAP_ON_KLEPTO | SAVE_FLAG_CAP_ON_MR_BLIZZARD | SAVE_FLAG_CAP_ON_UKIKI);
+                break;
+        }
     } else {
         gMarioState->flags = (MARIO_CAP_ON_HEAD | MARIO_NORMAL_CAP);
     }

--- a/src/game/save_file.c
+++ b/src/game/save_file.c
@@ -712,6 +712,12 @@ void save_file_move_cap_to_default_location(void) {
     }
 }
 
+u8 save_file_get_cap_level(void) {
+    struct SaveFile *saveFile = &gSaveBuffer.files[gCurrSaveFileNum - 1][0];
+
+    return saveFile->capLevel;
+}
+
 #ifdef VERSION_EU
 void eu_set_language(u16 language) {
     gSaveBuffer.menuData[0].language = language;

--- a/src/game/save_file.c
+++ b/src/game/save_file.c
@@ -714,7 +714,6 @@ void save_file_move_cap_to_default_location(void) {
 
 u8 save_file_get_cap_level(void) {
     struct SaveFile *saveFile = &gSaveBuffer.files[gCurrSaveFileNum - 1][0];
-
     return saveFile->capLevel;
 }
 

--- a/src/game/save_file.h
+++ b/src/game/save_file.h
@@ -145,6 +145,7 @@ s32 save_file_get_cap_pos(Vec3s capPos);
 void save_file_set_sound_mode(u16 mode);
 u16 save_file_get_sound_mode(void);
 void save_file_move_cap_to_default_location(void);
+u8 save_file_get_cap_level(void);
 
 void disable_warp_checkpoint(void);
 void check_if_should_set_warp_checkpoint(struct WarpNode *warpNode);

--- a/src/sm64ap.cpp
+++ b/src/sm64ap.cpp
@@ -43,7 +43,7 @@ int sm64_cost_mips1 = 15;
 int sm64_cost_mips2 = 50;
 int msg_frame_duration = 90; // 3 Secounds at 30F/s
 int cur_msg_frame_duration = msg_frame_duration;
-std::queue<u32> delayed_queue;
+std::queue<int64_t> delayed_queue;
 
 std::map<int,int> map_entrances;
 std::set<int> course_dest_supported;
@@ -95,10 +95,8 @@ void SM64AP_RecvItem(int64_t idx, bool notify) {
             sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET] = true;
             break;
         case SM64AP_ID_1_HEALTH_PIP ... SM64AP_ID_GUST_TRAP:
-            if(!notify) {
-                break;
-            }
-            SM64AP_PushDelayedStack(idx);
+            if(!notify) break;
+            delayed_queue.push(idx);
             break;
     }
 }
@@ -417,16 +415,10 @@ void SM64AP_SendItem(int idx) {
     AP_SendItem(idx);
 }
 
-// Push a delayed item onto the stack
-void SM64AP_PushDelayedStack(int64_t idx) {
-    delayed_queue.push(idx & 0xFFFFFFFF);
-}
 // If an item exists on the stack, return it, otherwise 0
-u32 SM64AP_PopDelayedStack() {
-    if(delayed_queue.empty()) {
-        return 0;
-    }
-    u32 item = delayed_queue.front();
+int64_t SM64AP_PopDelayedStack() {
+    if(delayed_queue.empty()) return 0;
+    int64_t item = delayed_queue.front();
     delayed_queue.pop();
     return item;
 }

--- a/src/sm64ap.cpp
+++ b/src/sm64ap.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include <cstdio>
 #include <bitset>
 #include <set>
+#include <queue>
 
 #define WARP_NODE_CREDITS_MIN 0xF8 // level_update.c
 #define NUM_PAINTING_LOCKS 15
@@ -42,6 +43,7 @@ int sm64_cost_mips1 = 15;
 int sm64_cost_mips2 = 50;
 int msg_frame_duration = 90; // 3 Secounds at 30F/s
 int cur_msg_frame_duration = msg_frame_duration;
+std::queue<u32> delayed_queue;
 
 std::map<int,int> map_entrances;
 std::set<int> course_dest_supported;
@@ -81,16 +83,22 @@ void SM64AP_RecvItem(int64_t idx, bool notify) {
         case SM64AP_ID_CANNONUNLOCK(0) ... SM64AP_ID_CANNONUNLOCK(15-1):
             sm64_have_cannon[idx-(SM64AP_ID_CANNONUNLOCK(0))] = true;
             break;
-    case SM64AP_ID_PAINTINGUNLOCK(0) ... SM64AP_ID_PAINTINGUNLOCK(NUM_PAINTING_LOCKS-1):
-        // We don't have a painting unlock for BoB, so (0) will never appear; index 1 corresponds to WF, and so on
-        sm64_have_painting[idx-(SM64AP_ID_PAINTINGUNLOCK(0))] = true;
-        break;
+        case SM64AP_ID_PAINTINGUNLOCK(0) ... SM64AP_ID_PAINTINGUNLOCK(NUM_PAINTING_LOCKS-1):
+            // We don't have a painting unlock for BoB, so (0) will never appear; index 1 corresponds to WF, and so on
+            sm64_have_painting[idx-(SM64AP_ID_PAINTINGUNLOCK(0))] = true;
+            break;
         case SM64AP_ID_ABILITY(0):
             sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET+1] = sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET];
             sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET] = true;
             break;
         case SM64AP_ID_ABILITY(1) ... SM64AP_ID_ABILITY(SM64AP_NUM_ABILITIES-1):
             sm64_have_abilities[idx-SM64AP_ABILITY_OFFSET] = true;
+            break;
+        case SM64AP_ID_1_HEALTH_PIP ... SM64AP_ID_GUST_TRAP:
+            if(!notify) {
+                break;
+            }
+            SM64AP_PushDelayedStack(idx);
             break;
     }
 }
@@ -407,6 +415,20 @@ void SM64AP_SendByBoxID(int id) {
 
 void SM64AP_SendItem(int idx) {
     AP_SendItem(idx);
+}
+
+// Push a delayed item onto the stack
+void SM64AP_PushDelayedStack(int64_t idx) {
+    delayed_queue.push(idx & 0xFFFFFFFF);
+}
+// If an item exists on the stack, return it, otherwise 0
+u32 SM64AP_PopDelayedStack() {
+    if(delayed_queue.empty()) {
+        return 0;
+    }
+    u32 item = delayed_queue.front();
+    delayed_queue.pop();
+    return item;
 }
 
 void SM64AP_FinishBowser(int i) {

--- a/src/sm64ap.h
+++ b/src/sm64ap.h
@@ -40,6 +40,21 @@ extern "C" {
 #define SM64AP_ID_CANNONUNLOCK(x) (SM64AP_ID_OFFSET+200+x)
 #define SM64AP_ID_PAINTINGUNLOCK(x) (SM64AP_ID_OFFSET+230+x)
 #define SM64AP_ID_ABILITY(x) (SM64AP_ABILITY_OFFSET+x)
+// Reserving some room for coins, if needed
+// Nice filler
+#define SM64AP_ID_1_HEALTH_PIP   (SM64AP_ID_OFFSET+1750)
+#define SM64AP_ID_2_HEALTH_PIP   (SM64AP_ID_OFFSET+1751)
+#define SM64AP_ID_3_HEALTH_PIP   (SM64AP_ID_OFFSET+1752)
+#define SM64AP_ID_4_HEALTH_PIP   (SM64AP_ID_OFFSET+1753)
+#define SM64AP_ID_FULL_REFILL    (SM64AP_ID_OFFSET+1754)
+// Traps
+#define SM64AP_ID_BONK_TRAP      (SM64AP_ID_OFFSET+1760)
+#define SM64AP_ID_FIRE_TRAP      (SM64AP_ID_OFFSET+1761)
+#define SM64AP_ID_ELEC_TRAP      (SM64AP_ID_OFFSET+1762)
+#define SM64AP_ID_CHUCK_TRAP     (SM64AP_ID_OFFSET+1763)
+#define SM64AP_ID_SPIN_TRAP      (SM64AP_ID_OFFSET+1764)
+#define SM64AP_ID_GUST_TRAP      (SM64AP_ID_OFFSET+1765)
+
 
 #define SM64AP_LOCATIONID_BOARDBOWSERSSUB (SM64AP_ID_OFFSET + 56)
 #define SM64AP_LOCATIONID_BASEMENTTOAD (SM64AP_ID_OFFSET + 168)
@@ -93,6 +108,11 @@ AP_EXTERN_C void SM64AP_SendItem(int);
 
 // Print Next Message to Screen
 AP_EXTERN_C void SM64AP_PrintNext();
+
+// Push a delayed item onto the stack
+AP_EXTERN_C void SM64AP_PushDelayedStack(int64_t);
+// If an item exists on the stack, return it, otherwise 0
+AP_EXTERN_C u32  SM64AP_PopDelayedStack();
 
 // Called on each Bowser stage completion, i is bowser index. Will send StoryComplete depending on completion option.
 AP_EXTERN_C void SM64AP_FinishBowser(int i);

--- a/src/sm64ap.h
+++ b/src/sm64ap.h
@@ -109,10 +109,8 @@ AP_EXTERN_C void SM64AP_SendItem(int);
 // Print Next Message to Screen
 AP_EXTERN_C void SM64AP_PrintNext();
 
-// Push a delayed item onto the stack
-AP_EXTERN_C void SM64AP_PushDelayedStack(int64_t);
 // If an item exists on the stack, return it, otherwise 0
-AP_EXTERN_C u32  SM64AP_PopDelayedStack();
+AP_EXTERN_C int64_t SM64AP_PopDelayedStack();
 
 // Called on each Bowser stage completion, i is bowser index. Will send StoryComplete depending on completion option.
 AP_EXTERN_C void SM64AP_FinishBowser(int i);


### PR DESCRIPTION
## What is this fixing or adding?
Adds 11 new filler items and 12 new options to control the distribution of filler items.
The new filler items are:
* 1 health pip restore
* 2 health pip restore
* 3 health pip restore
* 4 health pip restore
* Full health restore
* Bonk trap
* Fire trap
* Amp trap
* Chuckya trap
* Spin trap
* Gust trap

The new options are simple 0-100 values that are then used for the relative proportions when generating filler. This uses python's built-in [random.choices](https://docs.python.org/3/library/random.html#random.choices) with the world's random instance to generate the filler items.
The default for the options matches the current behavior, disabling all filler items beyond the 1-Up by setting their proportion to 0.

During gameplay, 1-Ups are unchanged and apply immediately. All the others are on a new delayed queue system that limits the item applying to the player to when they inside a course and are performing normal movement (running, jumping, swimming, etc) so that it doesn't interrupt cutscenes. It also enforces an at-least-100 frame delay between each item popping so that traps that take longer than others (gust trap, spin trap, etc) have time to resolve.

Items can accumulate while the player is not connected and they will be dequeued from Archipelago when they rejoin.

The traps are reused interactions from existing Mario enemies:
* Bonk trap simply uses the same interaction as Mario hitting a wall, in a random direction
* Fire trap sets Mario on fire like interacting with a flamethrower or one of Bowser's fireballs
* Amp trap shocks Mario like an Amp and takes 1 pip of health
* Chuckya trap throws Mario up and out in a random direction, like a Chuckya
* Spin trap spins Mario up into the air like a Tweester
* Gust trap blows Mario in a random direction like the giant snowman in Snowman's Land (including throwing his hat away, if he blows far enough away)

Because the gust trap can remove Mario's hat, this also makes a change to the underlying hat-handling code to handle unsuitable levels. Most levels do not have a default position to place the hat if Mario loses it and exits the level, so we put it back onto Mario's head upon exit if he loses it in one of these levels.
The only levels that properly handle Mario losing his hat are SSL, SL, and TTM, so this applies to all other levels.

This may allow some sequence breaking in rare circumstances (especially the Chuckya/Spin/Gust traps) if Mario is moved by the trap into an area that he would not normally be able to get.

## How was this tested?
* Ran a few generations while debug-printing the output of the item distribution to verify it roughly follows the requested ratios of filler
* Verified that the communication between Archipelago and SM64 was working properly to transmit the items, including the catch-up when the client is disconnected
* Ensured that when a star contains one of the traps, the star interaction is not interrupted
* Verified that losing Mario's hat in various unsuitable levels gives it back to him properly on exit

## If this makes graphical changes, please attach screenshots.
Apologies for the weird graphical glitches coming through the videos, I'm not sure why my screen capture included flashes of my desktop background. I blame Nvidia's poor support for Linux (warranted or not).

Bonk Trap
https://github.com/user-attachments/assets/d606d124-db6e-439f-9b02-3ede588388c3

Fire Trap
https://github.com/user-attachments/assets/84d6dc32-6ece-4bee-88d7-e240ee45e27a

Amp Trap
https://github.com/user-attachments/assets/1038c108-1ab0-42ce-8cb1-3261496b5c3e

Chuckya Trap
https://github.com/user-attachments/assets/27791149-4570-43e7-861c-f2e23e54a3b8

Spin Trap
https://github.com/user-attachments/assets/539a0f2f-e1e6-4841-ba5e-128cfe692c46

Gust Trap
https://github.com/user-attachments/assets/80e97595-1b77-42bd-9471-2d86b4189e29