### PR TITLE
set cmake c flags appropriately for gcc<15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1030,8 +1030,16 @@ else
   endif
 endif
 
+CMAKE_CFLAGS:="-fzero-init-padding-bits=unions"
+# Check if gcc<15 is being used, set gcc flags appropriately
+GCC_MAJORVERSION:=$(shell gcc -dumpversion)
+GCC_MAJORVERSION_BELOW15:=$(shell expr $(GCC_MAJORVERSION) \< 15)
+ifeq ($(GCC_MAJORVERSION_BELOW15),1)
+  CMAKE_CFLAGS:=""
+endif
+
 $(APCPP_LIB): lib/APCpp/Archipelago.cpp lib/APCpp/Archipelago.h
-	cd lib/APCpp && mkdir -p build && cd build && CXX=$(CXX) cmake .. $(CMAKE_WIN_BUILD_FLAG) -DMBEDTLS_FATAL_WARNINGS=OFF -DCMAKE_C_FLAGS="-fzero-init-padding-bits=unions" && CXX=$(CXX) cmake --build .
+	cd lib/APCpp && mkdir -p build && cd build && CXX=$(CXX) cmake .. $(CMAKE_WIN_BUILD_FLAG) -DMBEDTLS_FATAL_WARNINGS=OFF -DCMAKE_C_FLAGS=$(CMAKE_CFLAGS) && CXX=$(CXX) cmake --build .
 
 $(EXE): $(O_FILES) $(MIO0_FILES:.mio0=.o) $(SOUND_OBJ_FILES) $(ULTRA_O_FILES) $(GODDARD_O_FILES) $(if $(RPC_LIBS),$(BUILD_DIR)/$(RPC_LIBS),) $(APCPP_LIB)
 	$(LD) $(LDFLAGS_STATIC) -L $(BUILD_DIR) -o $@ $(O_FILES) $(SOUND_OBJ_FILES) $(ULTRA_O_FILES) $(GODDARD_O_FILES) $(LDFLAGS) $(APCPP_LIB) -Wl,-rpath,.


### PR DESCRIPTION
This PR relates to issue https://github.com/N00byKing/sm64ex/issues/26.

The flag -fzero-init-padding-bits=unions is only available starting in gcc 15, which is currently not supported by the stable releases of several Linux distributions. This PR checks the GCC major version in the makefile, and removes the flag if the GCC major version is below 15.