### PR TITLE
Add ability to return to title screen from the end screen

### DIFF
--- a/levels/ending/script.c
+++ b/levels/ending/script.c
@@ -15,6 +15,7 @@
 
 #include "make_const_nonconst.h"
 #include "levels/ending/header.h"
+#include "levels/intro/header.h"
 
 const LevelScript level_ending_entry[] = {
     /*0*/ INIT_LEVEL(),
@@ -31,7 +32,9 @@ const LevelScript level_ending_entry[] = {
     /*12*/ TRANSITION(/*transType*/ WARP_TRANSITION_FADE_FROM_COLOR, /*time*/ 75, /*color*/ 0x00, 0x00, 0x00),
     /*14*/ SLEEP(/*frames*/ 120),
     /*15*/ CALL(/*arg*/ 0, /*func*/ lvl_play_the_end_screen_sound),
-    // L1:
-    /*17*/ SLEEP(/*frames*/ 1),
-    /*18*/ JUMP(level_ending_entry + 17),
+    // The following lines were added/altered to allow the player to reset
+    /*17*/ CALL_LOOP(/*arg*/ 1, /*func*/ credits_end_wait_for_reset),
+    /*18*/ TRANSITION(/*transType*/ WARP_TRANSITION_FADE_INTO_COLOR, /*time*/ 75, /*color*/ 0x00, 0x00, 0x00),
+    /*19*/ SLEEP(/*frames*/ 120),
+    /*20*/ EXECUTE(/*seg*/ 0x14, /*script*/ _introSegmentRomStart, /*scriptEnd*/ _introSegmentRomEnd, /*entry*/ level_intro_entry_2),
 };

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -1402,3 +1402,11 @@ s32 lvl_play_the_end_screen_sound(UNUSED s16 arg0, UNUSED s32 arg1) {
     play_sound(SOUND_MENU_THANK_YOU_PLAYING_MY_GAME, gDefaultSoundArgs);
     return 1;
 }
+
+// Added so the player can reset the game at the end screen
+s32 credits_end_wait_for_reset() {
+    if (gPlayer1Controller->buttonPressed & START_BUTTON) {
+        return 1;
+    }
+    return 0;
+}

--- a/src/game/level_update.h
+++ b/src/game/level_update.h
@@ -127,6 +127,7 @@ s32 lvl_init_or_update(s16 initOrUpdate, UNUSED s32 unused);
 s32 lvl_init_from_save_file(UNUSED s16 arg0, s32 levelNum);
 s32 lvl_set_current_level(UNUSED s16 arg0, s32 levelNum);
 s32 lvl_play_the_end_screen_sound(UNUSED s16 arg0, UNUSED s32 arg1);
+s32 credits_end_wait_for_reset();
 void basic_update(UNUSED s16 *arg);
 struct WarpNode *get_painting_warp_node(void);
 


### PR DESCRIPTION
Based on the original patch https://discord.com/channels/707763437975109784/716459185230970880/753407837555785828

Ported with permission from the original patch's author, who has been given coauthorship. This allows returning to the title screen after getting to the end screen, rather than forcing you to close/reopen the game. Helpful in all bowser goal, where end credits may not be the end of the game, and in games without release, where you may have more to do post-goal